### PR TITLE
docs: add repository overview and formatter

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 mulatta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# buzz.nix
+
+Reproducible Nix packages for [block/buzz](https://github.com/block/buzz).
+
+This flake pins Buzz to the release tag recorded in `packages/source/hashes.json` and builds the Rust, web, relay, and desktop artifacts without import-from-derivation.
+
+## Packages
+
+| Package                 | Description                                                          |
+| ----------------------- | -------------------------------------------------------------------- |
+| `buzz-cli`              | Buzz command-line client (`buzz`)                                    |
+| `buzz-acp`              | ACP harness for Buzz agent integrations                              |
+| `buzz-agent`            | Minimal ACP-compliant Buzz agent                                     |
+| `buzz-dev-mcp`          | MCP server for shell and file-edit tools                             |
+| `git-credential-nostr`  | Git credential helper for NIP-98 authentication                      |
+| `buzz-agent-tools`      | Convenience bundle for CLI and agent tools                           |
+| `buzz-web`              | Web client bundle                                                    |
+| `buzz-admin-web`        | Relay administration UI bundle                                       |
+| `buzz-server-binaries`  | Server binary bundle (`buzz-relay`, `buzz-admin`, `buzz-pair-relay`) |
+| `buzz-relay`            | Relay runtime package with bundled web UIs                           |
+| `buzz-desktop-frontend` | Frontend bundle embedded in Buzz Desktop                             |
+| `buzz-desktop-sidecars` | Sidecar bundle required by Buzz Desktop                              |
+| `buzz-desktop`          | Tauri desktop application                                            |
+
+## Usage
+
+Run the CLI:
+
+```sh
+nix run github:mulatta/buzz.nix#buzz-cli -- --help
+```
+
+Run the relay:
+
+```sh
+nix run github:mulatta/buzz.nix#buzz-relay
+```
+
+`buzz-relay` expects runtime services such as Postgres to be configured. A bare run starts the binary, but database connection failures are expected without a database and `DATABASE_URL`.
+
+Build the desktop package:
+
+```sh
+nix build github:mulatta/buzz.nix#buzz-desktop
+```
+
+## Development
+
+Enter the development shell:
+
+```sh
+nix develop
+```
+
+Run focused checks:
+
+```sh
+NIX_CONFIG='allow-import-from-derivation = false' nix flake show
+nix build .#checks.aarch64-darwin.package-buzz-cli --no-link
+nix build .#checks.aarch64-darwin.package-buzz-desktop --no-link
+nix build .#checks.x86_64-linux.package-buzz-desktop --no-link
+```
+
+Format Nix files:
+
+```sh
+nix fmt
+```
+
+## Layout
+
+- `packages/*/package.nix` are public flake package definitions.
+- `packages/source` and `packages/pnpm-deps` are internal derivations used by the package scope.
+- `lib` contains shared package helpers exposed through `lib.buzz`.
+
+## Licensing
+
+The Nix packaging code in this repository is licensed under the MIT License.
+
+Packaged software keeps its upstream licenses. Buzz server and agent components are Apache-2.0. The desktop package is marked GPL-3.0-or-later because the final desktop binary includes sherpa-onnx/eSpeak NG native code.

--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@ This flake pins Buzz to the release tag recorded in `packages/source/hashes.json
 
 ## Packages
 
-| Package                 | Description                                                          |
+| Package | Description |
 | ----------------------- | -------------------------------------------------------------------- |
-| `buzz-cli`              | Buzz command-line client (`buzz`)                                    |
-| `buzz-acp`              | ACP harness for Buzz agent integrations                              |
-| `buzz-agent`            | Minimal ACP-compliant Buzz agent                                     |
-| `buzz-dev-mcp`          | MCP server for shell and file-edit tools                             |
-| `git-credential-nostr`  | Git credential helper for NIP-98 authentication                      |
-| `buzz-agent-tools`      | Convenience bundle for CLI and agent tools                           |
-| `buzz-web`              | Web client bundle                                                    |
-| `buzz-admin-web`        | Relay administration UI bundle                                       |
-| `buzz-server-binaries`  | Server binary bundle (`buzz-relay`, `buzz-admin`, `buzz-pair-relay`) |
-| `buzz-relay`            | Relay runtime package with bundled web UIs                           |
-| `buzz-desktop-frontend` | Frontend bundle embedded in Buzz Desktop                             |
-| `buzz-desktop-sidecars` | Sidecar bundle required by Buzz Desktop                              |
-| `buzz-desktop`          | Tauri desktop application                                            |
+| `buzz-cli` | Buzz command-line client (`buzz`) |
+| `buzz-acp` | ACP harness for Buzz agent integrations |
+| `buzz-agent` | Minimal ACP-compliant Buzz agent |
+| `buzz-dev-mcp` | MCP server for shell and file-edit tools |
+| `git-credential-nostr` | Git credential helper for NIP-98 authentication |
+| `buzz-agent-tools` | Convenience bundle for CLI and agent tools |
+| `buzz-web` | Web client bundle |
+| `buzz-admin-web` | Relay administration UI bundle |
+| `buzz-server-binaries` | Server binary bundle (`buzz-relay`, `buzz-admin`, `buzz-pair-relay`) |
+| `buzz-relay` | Relay runtime package with bundled web UIs |
+| `buzz-desktop-frontend` | Frontend bundle embedded in Buzz Desktop |
+| `buzz-desktop-sidecars` | Sidecar bundle required by Buzz Desktop |
+| `buzz-desktop` | Tauri desktop application |
 
 ## Usage
 

--- a/flake.nix
+++ b/flake.nix
@@ -14,11 +14,10 @@
   };
 
   outputs =
-    {
+    inputs@{
       self,
       nixpkgs,
       rust-overlay,
-      treefmt-nix,
       ...
     }:
     let
@@ -41,24 +40,13 @@
         }
       );
 
-      treefmtEval = eachSystem (
-        system:
-        treefmt-nix.lib.evalModule pkgsFor.${system} {
-          projectRootFile = "flake.nix";
-          programs = {
-            deadnix.enable = true;
-            keep-sorted.enable = true;
-            nixfmt.enable = true;
-            statix.enable = true;
-          };
-        }
-      );
     in
     {
       packages = eachSystem (
         system:
         import ./packages {
-          inherit lib;
+          inherit inputs lib;
+          flake = self;
           pkgs = pkgsFor.${system};
         }
       );
@@ -68,17 +56,17 @@
         lib.mapAttrs' (name: package: lib.nameValuePair "package-${name}" package) self.packages.${system}
         // {
           devshell-default = self.devShells.${system}.default;
-          formatting = treefmtEval.${system}.config.build.check self;
+          formatting = self.packages.${system}.formatter.passthru.tests.check;
         }
       );
 
       devShells = eachSystem (system: {
         default = import ./devshell.nix {
           pkgs = pkgsFor.${system};
-          formatter = treefmtEval.${system}.config.build.wrapper;
+          formatter = self.packages.${system}.formatter;
         };
       });
 
-      formatter = eachSystem (system: treefmtEval.${system}.config.build.wrapper);
+      formatter = eachSystem (system: self.packages.${system}.formatter);
     };
 }

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -1,4 +1,6 @@
 {
+  flake,
+  inputs,
   lib,
   pkgs,
 }:
@@ -16,7 +18,11 @@ let
     self:
     {
       # Use extended flake lib so package.nix files can access lib.buzz helpers.
-      inherit lib;
+      inherit
+        flake
+        inputs
+        lib
+        ;
 
       source = self.callPackage ./source { };
       pnpmDeps = self.callPackage ./pnpm-deps {

--- a/packages/formatter/package.nix
+++ b/packages/formatter/package.nix
@@ -1,0 +1,45 @@
+{
+  flake,
+  inputs,
+  pkgs,
+}:
+
+let
+  formatter = inputs.treefmt-nix.lib.mkWrapper pkgs {
+    _file = __curPos.file;
+    imports = [ ./treefmt.nix ];
+  };
+
+  check =
+    pkgs.runCommand "format-check"
+      {
+        nativeBuildInputs = [
+          formatter
+          pkgs.git
+        ];
+      }
+      ''
+        export HOME=$NIX_BUILD_TOP/home
+
+        cp --preserve=mode,timestamps -r ${flake} source
+        cd source
+        chmod -R u+w .
+        git init --quiet
+        git add .
+        treefmt --no-cache
+        if ! git diff --exit-code; then
+          echo "-------------------------------"
+          echo "aborting due to above changes ^"
+          exit 1
+        fi
+        touch $out
+      '';
+in
+formatter
+// {
+  passthru = formatter.passthru // {
+    tests = {
+      inherit check;
+    };
+  };
+}

--- a/packages/formatter/treefmt.nix
+++ b/packages/formatter/treefmt.nix
@@ -1,0 +1,14 @@
+_:
+
+{
+  projectRootFile = "flake.nix";
+
+  programs = {
+    deadnix.enable = true;
+    keep-sorted.enable = true;
+    mdformat.enable = true;
+    nixfmt.enable = true;
+    statix.enable = true;
+    yamlfmt.enable = true;
+  };
+}


### PR DESCRIPTION
## Summary

- add README and MIT license for the packaging repository
- document available Buzz packages, usage, development checks, and layout conventions
- expose the repository formatter as a flake package and wire formatting checks through it
- enable Markdown and YAML formatting alongside the existing Nix formatters

## Validation

- `nix fmt`
- `git diff --check`
- `NIX_CONFIG='allow-import-from-derivation = false' nix flake show`
- `nix build --accept-flake-config .#checks.aarch64-darwin.formatting --no-link`
