### PR TITLE
workflow: automate buzz updater PR merges

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -12,3 +12,6 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: Mic92/auto-merge@main
+        with:
+          use-auto-merge: true
+          merge-method: merge

--- a/.github/workflows/update-buzz-source.yml
+++ b/.github/workflows/update-buzz-source.yml
@@ -51,8 +51,11 @@ jobs:
         if: steps.update.outputs.updated == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OLD_VERSION: ${{ steps.update.outputs.old_version }}
           NEW_VERSION: ${{ steps.update.outputs.new_version }}
         run: |
+          title="buzz: ${OLD_VERSION} -> ${NEW_VERSION}"
+          compare_url="https://github.com/block/buzz/compare/v${OLD_VERSION}...v${NEW_VERSION}"
           branch="update/buzz-${NEW_VERSION}"
           git checkout -B "$branch"
           git add \
@@ -64,7 +67,10 @@ jobs:
             echo "Updater reported changes but produced no managed metadata diff" >&2
             exit 1
           fi
-          git commit -m "source: pin buzz ${NEW_VERSION}"
+          git commit \
+            --signoff \
+            -m "$title" \
+            -m "$compare_url"
 
           remote_sha=$(git ls-remote --heads origin "$branch" | cut -f1)
           if [ -n "$remote_sha" ]; then
@@ -77,14 +83,14 @@ jobs:
 
           if gh pr view "$branch" --json number >/dev/null 2>&1; then
             gh pr edit "$branch" \
-              --title "source: pin buzz ${NEW_VERSION}" \
-              --body "Automated update of the pinned block/buzz source to ${NEW_VERSION}."
+              --title "$title" \
+              --body "$compare_url"
           else
             gh pr create \
               --base main \
               --head "$branch" \
-              --title "source: pin buzz ${NEW_VERSION}" \
-              --body "Automated update of the pinned block/buzz source to ${NEW_VERSION}."
+              --title "$title" \
+              --body "$compare_url"
           fi
 
           gh pr merge "$branch" --auto --merge

--- a/.github/workflows/update-buzz-source.yml
+++ b/.github/workflows/update-buzz-source.yml
@@ -18,9 +18,16 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
@@ -32,7 +39,7 @@ jobs:
       - name: Update source pin
         id: update
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           UPDATE_TAG: ${{ inputs.tag }}
         run: |
           if [ -n "$UPDATE_TAG" ]; then
@@ -43,7 +50,7 @@ jobs:
       - name: Create pull request
         if: steps.update.outputs.updated == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEW_VERSION: ${{ steps.update.outputs.new_version }}
         run: |
           branch="update/buzz-${NEW_VERSION}"
@@ -79,3 +86,5 @@ jobs:
               --title "source: pin buzz ${NEW_VERSION}" \
               --body "Automated update of the pinned block/buzz source to ${NEW_VERSION}."
           fi
+
+          gh pr merge "$branch" --auto --merge

--- a/.github/workflows/update-buzz-source.yml
+++ b/.github/workflows/update-buzz-source.yml
@@ -49,7 +49,7 @@ jobs:
           branch="update/buzz-${NEW_VERSION}"
           git checkout -B "$branch"
           git add \
-            packages/source/hashes.json \
+            packages/source/pin.json \
             packages/build-buzz-frontend/hashes.json \
             packages/build-buzz-rust/hashes.json \
             packages/buzz-desktop/hashes.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Reproducible Nix packages for [block/buzz](https://github.com/block/buzz).
 
-This flake pins Buzz to the release tag recorded in `packages/source/hashes.json` and builds the Rust, web, relay, and desktop artifacts without import-from-derivation.
+This flake pins Buzz to the release tag recorded in `packages/source/pin.json` and builds the Rust, web, relay, and desktop artifacts without import-from-derivation.
 
 ## Packages
 
@@ -78,7 +78,7 @@ Omit `--tag` to use the latest upstream release.
 ## Layout
 
 - `packages/*/package.nix` are public flake package definitions.
-- `packages/source` provides the pinned upstream source and release metadata.
+- `packages/source` provides the pinned upstream source plus source-derived metadata needed at evaluation time.
 - `packages/build-buzz-frontend` and `packages/build-buzz-rust` are package-scoped internal builders with locally owned dependency hashes.
 
 ## Licensing

--- a/packages/source/default.nix
+++ b/packages/source/default.nix
@@ -4,12 +4,15 @@
 }:
 
 let
-  data = lib.importJSON ./hashes.json;
+  data = lib.importJSON ./pin.json;
 
+  # Keep source-derived metadata in pin.json so evaluation does not need to read
+  # Cargo.toml or rust-toolchain.toml from the fetched source.
   src = fetchFromGitHub {
     owner = "block";
     repo = "buzz";
-    inherit (data) rev hash;
+    rev = "v${data.version}";
+    inherit (data) hash;
   };
 in
 {
@@ -18,6 +21,5 @@ in
     version
     relayVersion
     rustVersion
-    rev
     ;
 }

--- a/packages/source/pin.json
+++ b/packages/source/pin.json
@@ -2,6 +2,5 @@
   "version": "0.5.2",
   "relayVersion": "0.2.0",
   "rustVersion": "1.95.0",
-  "rev": "v0.5.2",
   "hash": "sha256-VWqoIS5FMyou6fEuuUq1OUIPycAtn0kVLbm5yCQAsOs="
 }

--- a/packages/source/update.py
+++ b/packages/source/update.py
@@ -390,8 +390,13 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
+    old_version = load_json(SOURCE_PIN_PATH).get("version")
+    if not isinstance(old_version, str):
+        raise RuntimeError(f"version is missing or invalid in {SOURCE_PIN_PATH}")
+
     tag = require_release_tag(args.tag) if args.tag else latest_tag()
     changed = update(tag, force=args.force)
+    write_output("old_version", old_version)
     write_output("new_version", tag.removeprefix("v"))
     write_output("updated", str(changed).lower())
 

--- a/packages/source/update.py
+++ b/packages/source/update.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SOURCE_HASHES_PATH = REPO_ROOT / "packages/source/hashes.json"
+SOURCE_PIN_PATH = REPO_ROOT / "packages/source/pin.json"
 FRONTEND_HASHES_PATH = REPO_ROOT / "packages/build-buzz-frontend/hashes.json"
 RUST_HASHES_PATH = REPO_ROOT / "packages/build-buzz-rust/hashes.json"
 DESKTOP_HASHES_PATH = REPO_ROOT / "packages/buzz-desktop/hashes.json"
@@ -282,20 +282,20 @@ def update(
     tag: str,
     *,
     force: bool = False,
-    source_hashes_path: Path = SOURCE_HASHES_PATH,
+    source_pin_path: Path = SOURCE_PIN_PATH,
     frontend_hashes_path: Path = FRONTEND_HASHES_PATH,
     rust_hashes_path: Path = RUST_HASHES_PATH,
     desktop_hashes_path: Path = DESKTOP_HASHES_PATH,
 ) -> bool:
     tag = require_release_tag(tag)
-    source_data = load_json(source_hashes_path)
+    source_data = load_json(source_pin_path)
     frontend_data = load_json(frontend_hashes_path)
     rust_data = load_json(rust_hashes_path)
     desktop_data = load_json(desktop_hashes_path)
     metadata = (source_data, frontend_data, rust_data, desktop_data)
 
     assert_no_fake_hashes(*metadata)
-    require_hash(source_data, "hash", source_hashes_path)
+    require_hash(source_data, "hash", source_pin_path)
     require_hash(frontend_data, "pnpmHash", frontend_hashes_path)
     require_hash(rust_data, "cargoHash", rust_hashes_path)
     require_hash(desktop_data, "cargoHash", desktop_hashes_path)
@@ -304,11 +304,12 @@ def update(
     if not isinstance(sherpa_data, dict):
         raise RuntimeError(f"sherpaOnnx is missing or invalid in {desktop_hashes_path}")
 
-    if source_data.get("rev") == tag and not force:
+    version = tag.removeprefix("v")
+    if source_data.get("version") == version and not force:
         return False
 
     managed_paths = (
-        source_hashes_path,
+        source_pin_path,
         frontend_hashes_path,
         rust_hashes_path,
         desktop_hashes_path,
@@ -317,7 +318,6 @@ def update(
 
     try:
         source_hash, source_path = prefetch_source(tag)
-        version = tag.removeprefix("v")
         relay_version = read_package_version(
             source_path / "crates/buzz-relay/Cargo.toml"
         )
@@ -335,11 +335,10 @@ def update(
                 "version": version,
                 "relayVersion": relay_version,
                 "rustVersion": rust_version,
-                "rev": tag,
                 "hash": source_hash,
             }
         )
-        save_json(source_hashes_path, source_data)
+        save_json(source_pin_path, source_data)
         save_json(desktop_hashes_path, desktop_data)
 
         refresh_fixed_output_hash(


### PR DESCRIPTION
This updates the Buzz source updater so automated release PRs are created with a GitHub App token, can trigger the auto-merge workflow, and use version bump titles with compare links and signed-off commits. It also renames the source metadata file to pin.json, derives the release tag from the pinned version, and keeps source-derived evaluation metadata without import-from-derivation