### PR TITLE
workflow: keep updater PR creation maintainable

### DIFF
--- a/.github/ci/create_pr.py
+++ b/.github/ci/create_pr.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Create or update the automated buzz source update pull request."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+
+MANAGED_PATHS = [
+    "packages/source/pin.json",
+    "packages/build-buzz-frontend/hashes.json",
+    "packages/build-buzz-rust/hashes.json",
+    "packages/buzz-desktop/hashes.json",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PullRequest:
+    branch: str
+    title: str
+    body: str
+
+
+def run(
+    cmd: list[str], *, check: bool = True, capture: bool = False
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        cmd,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        if capture:
+            sys.stdout.write(result.stdout)
+            sys.stderr.write(result.stderr)
+        raise RuntimeError(f"command failed with exit code {result.returncode}: {cmd}")
+    return result
+
+
+def remote_branch_sha(branch: str) -> str | None:
+    result = run(["git", "ls-remote", "--heads", "origin", branch], capture=True)
+    return result.stdout.split("\t", 1)[0].strip() or None
+
+
+def pr_exists(branch: str) -> bool:
+    return (
+        run(["gh", "pr", "view", branch, "--json", "number"], check=False).returncode
+        == 0
+    )
+
+
+def push_branch(branch: str) -> None:
+    remote_sha = remote_branch_sha(branch)
+    if remote_sha:
+        run(
+            [
+                "git",
+                "push",
+                f"--force-with-lease=refs/heads/{branch}:{remote_sha}",
+                "origin",
+                f"HEAD:refs/heads/{branch}",
+            ]
+        )
+    else:
+        run(["git", "push", "origin", f"HEAD:refs/heads/{branch}"])
+
+
+def create_or_update_pr(pr: PullRequest, *, auto_merge: bool) -> None:
+    run(["git", "checkout", "-B", pr.branch])
+    run(["git", "add", *MANAGED_PATHS])
+
+    if run(["git", "diff", "--cached", "--quiet"], check=False).returncode == 0:
+        raise RuntimeError(
+            "updater reported changes but produced no managed metadata diff"
+        )
+
+    run(["git", "commit", "--signoff", "-m", pr.title, "-m", pr.body])
+    push_branch(pr.branch)
+
+    if pr_exists(pr.branch):
+        run(["gh", "pr", "edit", pr.branch, "--title", pr.title, "--body", pr.body])
+    else:
+        run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--base",
+                "main",
+                "--head",
+                pr.branch,
+                "--title",
+                pr.title,
+                "--body",
+                pr.body,
+            ]
+        )
+
+    if auto_merge:
+        run(["gh", "pr", "merge", pr.branch, "--auto", "--merge"])
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("old_version", help="currently pinned buzz version")
+    parser.add_argument("new_version", help="new buzz version")
+    parser.add_argument(
+        "--no-auto-merge",
+        action="store_true",
+        help="create or update the PR without enabling GitHub auto-merge",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    if not os.environ.get("GH_TOKEN"):
+        raise RuntimeError("GH_TOKEN environment variable is not set")
+
+    args = parse_args()
+    pr = PullRequest(
+        branch=f"update/buzz-{args.new_version}",
+        title=f"buzz: {args.old_version} -> {args.new_version}",
+        body=(
+            "https://github.com/block/buzz/compare/"
+            f"v{args.old_version}...v{args.new_version}"
+        ),
+    )
+    create_or_update_pr(pr, auto_merge=not args.no_auto_merge)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/update-buzz-source.yml
+++ b/.github/workflows/update-buzz-source.yml
@@ -22,9 +22,9 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.CLIENT_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -32,6 +32,8 @@ jobs:
         with:
           extra_nix_config: |
             allow-import-from-derivation = false
+            extra-substituters = https://cache.mulatta.io
+            extra-trusted-public-keys = cache.mulatta.io-1:DrV+Oy2azNyVKM7ihhD1QoOetRUnW+1G6RWToUpSO4U=
       - name: Set up git
         run: |
           git config user.name "github-actions[bot]"
@@ -51,46 +53,7 @@ jobs:
         if: steps.update.outputs.updated == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          OLD_VERSION: ${{ steps.update.outputs.old_version }}
-          NEW_VERSION: ${{ steps.update.outputs.new_version }}
         run: |
-          title="buzz: ${OLD_VERSION} -> ${NEW_VERSION}"
-          compare_url="https://github.com/block/buzz/compare/v${OLD_VERSION}...v${NEW_VERSION}"
-          branch="update/buzz-${NEW_VERSION}"
-          git checkout -B "$branch"
-          git add \
-            packages/source/pin.json \
-            packages/build-buzz-frontend/hashes.json \
-            packages/build-buzz-rust/hashes.json \
-            packages/buzz-desktop/hashes.json
-          if git diff --cached --quiet; then
-            echo "Updater reported changes but produced no managed metadata diff" >&2
-            exit 1
-          fi
-          git commit \
-            --signoff \
-            -m "$title" \
-            -m "$compare_url"
-
-          remote_sha=$(git ls-remote --heads origin "$branch" | cut -f1)
-          if [ -n "$remote_sha" ]; then
-            git push \
-              --force-with-lease="refs/heads/$branch:$remote_sha" \
-              origin "HEAD:refs/heads/$branch"
-          else
-            git push origin "HEAD:refs/heads/$branch"
-          fi
-
-          if gh pr view "$branch" --json number >/dev/null 2>&1; then
-            gh pr edit "$branch" \
-              --title "$title" \
-              --body "$compare_url"
-          else
-            gh pr create \
-              --base main \
-              --head "$branch" \
-              --title "$title" \
-              --body "$compare_url"
-          fi
-
-          gh pr merge "$branch" --auto --merge
+          .github/ci/create_pr.py \
+            "${{ steps.update.outputs.old_version }}" \
+            "${{ steps.update.outputs.new_version }}"


### PR DESCRIPTION

Move the updater PR orchestration out of inline shell so the workflow is easier to review and reuse. Use the current GitHub App token input and checkout action while touching the workflow.


